### PR TITLE
Cleanup detectionOn.sh to improve performance

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -2,6 +2,9 @@
 # edit this file and move it to /system/sdcard/config/motion.conf #
 ############################################################
 
+# Enable verbose debug messages to stderr 
+debug_msg_enable=false
+
 # Configure the motion core parameters:
 
 region_of_interest=0,0,1280,720
@@ -20,7 +23,7 @@ publish_mqtt_message=false
 publish_mqtt_snapshot=false
 # Save the image locally
 save_snapshot=false
-sendemail=false
+send_email=false
 send_telegram=false
 save_dir=/system/sdcard/motion/stills
 save_file_date_pattern="+%d-%m-%Y_%H.%M.%S"

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -4,66 +4,99 @@
 . /system/sdcard/config/motion.conf
 . /system/sdcard/scripts/common_functions.sh
 
-include /system/sdcard/config/telegram.conf
+function debug_msg () {
+	if [ "$debug_msg_enable" == true ]; then
+		echo "DEBUG: $*" 1>&2
+	fi
+}
+
+# First, take a snapshot and record date ASAP
+snapshot_tempfile=$(mktemp /tmp/snapshot-XXXXXXX)
+snapshot_pattern="${save_file_date_pattern:-+%d-%m-%Y_%H.%M.%S}"
+snapshot_filename=$(date "$snapshot_pattern")
+/system/sdcard/bin/getimage > "$snapshot_tempfile"
+debug_msg "Got snapshot_tempfile=$snapshot_tempfile"
 
 # Turn on the amber led
 if [ "$motion_trigger_led" = true ] ; then
+	debug_msg "Trigger LED"
 	yellow_led on
 fi
 
+# Next, start background tasks for all configured notifications
+
 # Save a snapshot
 if [ "$save_snapshot" = true ] ; then
-	pattern="${save_file_date_pattern:-+%d-%m-%Y_%H.%M.%S}"
-	filename=$(date $pattern).jpg
+	(
+	debug_msg "Save snapshot to $save_dir/${snapshot_filename}.jpg"
+
 	if [ ! -d "$save_dir" ]; then
 		mkdir -p "$save_dir"
 	fi
-	{
-		# Limit the number of snapshots
-		if [ "$(ls "$save_dir" | wc -l)" -ge "$max_snapshots" ]; then
-			rm -f "$save_dir/$(ls -ltr "$save_dir" | awk 'NR==2{print $9}')"
-		fi
-	} &
-	/system/sdcard/bin/getimage > "$save_dir/$filename" &
+
+	# Limit the number of snapshots
+	if [ "$(ls "$save_dir" | wc -l)" -ge "$max_snapshots" ]; then
+		rm -f "$save_dir/$(ls -ltr "$save_dir" | awk 'NR==2{print $9}')"
+	fi
+
+	cp "$snapshot_tempfile" "$save_dir/${snapshot_filename}.jpg"
+	) &
 fi
 
 # Publish a mqtt message
-if [ "$publish_mqtt_message" = true ] ; then
+if [ "$publish_mqtt_message" = true -o "$publish_mqtt_snapshot" = true ] ; then
+	(
 	. /system/sdcard/config/mqtt.conf
-	/system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motion ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -m "ON"
+
+	if [ "$publish_mqtt_message" = true ] ; then
+		debug_msg "Send MQTT message"
+		/system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motion ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -m "ON"
+	fi
+
+	if [ "$publish_mqtt_snapshot" = true ] ; then
+		debug_msg "Send MQTT snapshot"
+		/system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motion/snapshot ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -f "$snapshot_tempfile"
+	fi
+	) &
 fi
 
-# The MQTT publish uses a separate image from the "save_snapshot" to keep things simple
-if [ "$publish_mqtt_snapshot" = true ] ; then
-	/system/sdcard/bin/getimage > /tmp/last_image.jpg
-	/system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motion/snapshot ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -f /tmp/last_image.jpg
-	rm /tmp/last_image.jpg
-fi
-
-# Send emails ...
+# Send emails
 if [ "$send_email" = true ] ; then
-    /system/sdcard/scripts/sendPictureMail.sh&
+	debug_msg "Send emails"
+	/system/sdcard/scripts/sendPictureMail.sh &
 fi
 
 # Send a telegram message
 if [ "$send_telegram" = true ]; then
+	(
+	include /system/sdcard/config/telegram.conf
+
 	if [ "$telegram_alert_type" = "text" ] ; then
+		debug_msg "Send telegram text"
 		/system/sdcard/bin/telegram m "Motion detected"
 	else
-		if [ "$save_snapshot" = true ] ; then
-			/system/sdcard/bin/telegram p "$save_dir/$filename"
-		else
-			/system/sdcard/bin/getimage > "/tmp/telegram_image.jpg"
-	 		/system/sdcard/bin/telegram p "/tmp/telegram_image.jpg"
-	 		rm "/tmp/telegram_image.jpg"
-		fi
+		debug_msg "Send telegram snapshot"
+		/system/sdcard/bin/telegram p "$snapshot_tempfile"
 	fi
+	) &
 fi
 
 # Run any user scripts.
 for i in /system/sdcard/config/userscripts/motiondetection/*; do
     if [ -x "$i" ]; then
-        echo "Running: $i on $save_dir/$filename"
-        $i on "$save_dir/$filename" &
+        debug_msg "Running: $i on $snapshot_tempfile"
+        $i on "$snapshot_tempfile" &
     fi
 done
+
+# Wait for all background jobs to finish before existing and deleting tempfile
+debug_msg "Waiting for background jobs to end:"
+for jobpid in $(jobs -p); do
+	wait "$jobpid"
+	debug_msg " Job $jobpid ended"
+done
+
+debug_msg "Cleanup snapshot_tempfile"
+rm "$snapshot_tempfile"
+
+debug_msg "DONE"


### PR DESCRIPTION
Modify as follows:
 1. Run `getimage` once at beginning of script, save image to /tmp
 2. Launch all notification tasks (save snapshot, mqtt, email, telegram,
    and user scripts) as background jobs, use same image image in all
    cases for consistency
 3. Wait for all background jobs to finish before deleting tempfile

In motion.conf.dist:
 * Add default debug_msg_enable=false
 * Fix typo: s/sendemail/send_email

Testing: Ran detectionOn.sh with all options+debugging enabled on a
Wyze Cam V2 and verified the following:
 * LED triggered
 * Snapshot jpg saved to sdcard
 * Old snapshots removed from sdcard
 * Ran few user scripts to read tempfile
 * sendPictureMail.sh, mosquitto_pub.bin, and telegram ran, but I
   didn't verify delivery