### PR TITLE
detectionOn.sh: Upload snapshot and/or video stream to ftp server

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -27,3 +27,14 @@ send_email=false
 send_telegram=false
 save_dir=/system/sdcard/motion/stills
 save_file_date_pattern="+%d-%m-%Y_%H.%M.%S"
+
+# Configure FTP snapshots and videos
+ftp_snapshot=false
+ftp_video=false
+ftp_video_duration=10
+ftp_host="ftp.myserver.net"
+ftp_port=21
+ftp_username="user1"
+ftp_password="password2"
+ftp_stills_dir="motion/stills"
+ftp_videos_dir="motion/videos"


### PR DESCRIPTION
Enabling `ftp_snapshot=true` in motion.conf uploads a single image to
ftp server on each motion event, similar to other handlers.

Enabling `ftp_video=true` starts a background task to stream 1fps video
until motion stops. It minimally steams for 10 seconds (configurable),
refreshing the countdown as motion continues.